### PR TITLE
odbc: Fix stack corruption in get_diagnos in odbcserver

### DIFF
--- a/c_src/odbcserver.c
+++ b/c_src/odbcserver.c
@@ -2797,6 +2797,11 @@ static diagnos get_diagnos(SQLSMALLINT handleType, SQLHANDLE handle, Boolean ext
             errmsg_buffer_size = errmsg_buffer_size - errmsg_size;
             acc_errmsg_size = acc_errmsg_size + errmsg_size;
             current_errmsg_pos = current_errmsg_pos + errmsg_size;
+        } else if(result == SQL_SUCCESS_WITH_INFO && errmsg_size >= errmsg_buffer_size) {
+            memcpy(diagnos.sqlState, current_sql_state, SQL_STATE_SIZE);
+            diagnos.nativeError = nativeError;
+            acc_errmsg_size = errmsg_buffer_size;
+            break;
         } else {
             break;
         }


### PR DESCRIPTION
SQLGetDiagRec can fill output buffer and return SQL_SUCCESS_WITH_INFO.
In that case we can not use strcat on diagnos.error_msg as it will write
outside allocated space.
Correctly set acc_errmsg_size in such case.

See also ERL-808 at bugs.erlang.org.

This is cherry-pick from https://github.com/erlang/otp/commit/75ae8bc8efa94103d68cb203c1e81088f9c38d32