### PR TITLE
Exclude priv/eodbcserver from hex package

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,12 @@ VARBINARY(MAX)))").
 {selected,[{{sql_wvarchar,536870911},"string"}],
           [{<<104,101,108,108,111,0>>}]}
 ```
+
+# Build HEX package
+
+Use rebar3 to compile a HEX package before releasing it to hex.pm:
+
+```
+rebar3 compile
+rebar3 hex build
+```

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{plugins, [ {pc, "1.11.0"} ]}.
+{plugins, [ {pc, "1.11.0"}, rebar3_hex ]}.
 {provider_hooks,
  [
   {pre,

--- a/src/eodbc.app.src
+++ b/src/eodbc.app.src
@@ -1,6 +1,6 @@
 {application, eodbc,
  [{description, "Erlang ODBC application"},
-  {vsn, "%VSN%"},
+  {vsn, git},
   {modules, [
 	     eodbc,
 	     eodbc_app,
@@ -10,6 +10,8 @@
 		eodbc_sup
 	       ]},
   {applications, [kernel, stdlib]},
-  {env,[]},
+  {env, []},
+  %% Tell rebar3_hex to not include the platform specific binary file
+  {exclude_paths, ["priv/eodbcserver"]},
   {mod, {eodbc_app, []}}]}.
 


### PR DESCRIPTION
Fixes MIM-1851. Enables cross-platform compatibility of hex package.

The changes include:
- Exclude priv/eodbcserver from hex package
- Enable hex rebar3 plugin
- Use version from git in app config

exclude_paths is not documented feature, but a hint is from that issue https://github.com/erlang/rebar3/issues/1202